### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Ron Lobo <code@ronlobo.com>"]
 edition = "2018"
 description = "On the fly value objects in Rust."
 readme = "./README.md"
-repository = "https://www.github.com/ronlobo/constrained_type"
+repository = "https://github.com/ronlobo/constrained_type"
 license = "MIT/Apache-2.0"
 
 [dependencies]


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96